### PR TITLE
Add GitHub Actions pipeline for contribution gradient

### DIFF
--- a/.github/workflows/contribution.yml
+++ b/.github/workflows/contribution.yml
@@ -1,0 +1,17 @@
+name: Contribution Gradient
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+jobs:
+  contribute:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Run gradient script
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: python gradient.py

--- a/README.md
+++ b/README.md
@@ -1,1 +1,44 @@
 # Contribution Gradient Art
+
+## Pipeline Goals
+
+This project aims to create visual gradient patterns on your GitHub contribution graph. The provided pipeline automatically commits to the repository on a schedule, gradually building the desired pattern over time.
+
+## Setup and Execution
+
+1. Create a personal access token with permissions to push to this repository.
+2. Add the token as a repository secret named `GH_TOKEN`.
+3. The GitHub Actions workflow located at `.github/workflows/contribution.yml` runs daily and can also be triggered manually from the Actions tab.
+4. When executed, the workflow runs `gradient.py`, which creates an empty commit and pushes it to the `main` branch using `GH_TOKEN`.
+
+### Local Run
+
+To test the script locally:
+
+```bash
+export GH_TOKEN=<your token>
+export GITHUB_REPOSITORY=<your repo>
+python gradient.py
+```
+
+## Example Workflow File
+
+```yaml
+name: Contribution Gradient
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+jobs:
+  contribute:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Run gradient script
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: python gradient.py
+```

--- a/gradient.py
+++ b/gradient.py
@@ -1,0 +1,20 @@
+import os
+import subprocess
+from datetime import datetime
+
+
+def run():
+    message = f"chore: update contribution {datetime.utcnow().isoformat()}"
+    subprocess.run(["git", "config", "--global", "user.email", "actions@github.com"], check=True)
+    subprocess.run(["git", "config", "--global", "user.name", "GitHub Actions"], check=True)
+    subprocess.run(["git", "commit", "--allow-empty", "-m", message], check=True)
+    token = os.getenv("GH_TOKEN")
+    repo = os.getenv("GITHUB_REPOSITORY")
+    if not token or not repo:
+        raise RuntimeError("Missing GH_TOKEN or GITHUB_REPOSITORY")
+    remote = f"https://x-access-token:{token}@github.com/{repo}.git"
+    subprocess.run(["git", "push", remote, "HEAD:main"], check=True)
+
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
## Summary
- add daily GitHub Actions workflow that runs `gradient.py`
- create simple script to commit empty changes for contribution art
- document pipeline usage in README

## Testing
- `python -m py_compile gradient.py`

------
https://chatgpt.com/codex/tasks/task_e_6867ab5ecfa88332a719d094f8ce257b